### PR TITLE
Add missing enumerable to re-export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,4 +39,7 @@ export {
   BundlingOptions,
   ICommandHooks,
   LogLevel,
+  OutputFormat,
+  SourceMapMode,
+  Charset,
 } from "aws-cdk-lib/aws-lambda-nodejs";


### PR DESCRIPTION
Adding missing enumerable `OutputFormat`, `SourceMapMode`, `Charset`